### PR TITLE
feat: zero amounts on Morpho actions

### DIFF
--- a/src/adapters/MorphoLendingAdapter.sol
+++ b/src/adapters/MorphoLendingAdapter.sol
@@ -114,8 +114,9 @@ contract MorphoLendingAdapter is IMorphoLendingAdapter, Initializable {
 
     /// @inheritdoc ILendingAdapter
     function addCollateral(uint256 amount) external {
-        IMorpho _morpho = morpho;
+        if (amount == 0) return;
 
+        IMorpho _morpho = morpho;
         MarketParams memory _marketParams = marketParams;
 
         // Transfer the collateral from msg.sender to this contract
@@ -128,20 +129,23 @@ contract MorphoLendingAdapter is IMorphoLendingAdapter, Initializable {
 
     /// @inheritdoc ILendingAdapter
     function removeCollateral(uint256 amount) external onlyLeverageManager {
+        if (amount == 0) return;
         // Withdraw the collateral from the Morpho market and send it to msg.sender
         morpho.withdrawCollateral(marketParams, amount, address(this), msg.sender);
     }
 
     /// @inheritdoc ILendingAdapter
     function borrow(uint256 amount) external onlyLeverageManager {
+        if (amount == 0) return;
         // Borrow the debt asset from the Morpho market and send it to the caller
         morpho.borrow(marketParams, amount, 0, address(this), msg.sender);
     }
 
     /// @inheritdoc ILendingAdapter
     function repay(uint256 amount) external {
-        IMorpho _morpho = morpho;
+        if (amount == 0) return;
 
+        IMorpho _morpho = morpho;
         MarketParams memory _marketParams = marketParams;
 
         // Transfer the debt asset from msg.sender to this contract

--- a/test/unit/LendingAdapter/morpho/AddCollateral.t.sol
+++ b/test/unit/LendingAdapter/morpho/AddCollateral.t.sol
@@ -12,6 +12,8 @@ contract MorphoLendingAdapterAddCollateralTest is MorphoLendingAdapterBaseTest {
     address public alice = makeAddr("alice");
 
     function testFuzz_addCollateral(uint256 amount) public {
+        vm.assume(amount > 0);
+
         // Deal alice the required collateral
         deal(address(collateralToken), alice, amount);
 
@@ -37,5 +39,11 @@ contract MorphoLendingAdapterAddCollateralTest is MorphoLendingAdapterBaseTest {
         vm.stopPrank();
 
         assertEq(collateralToken.balanceOf(address(morpho)), amount);
+    }
+
+    function test_addCollateral_ZeroAmount() public {
+        // Nothing happens
+        lendingAdapter.addCollateral(0);
+        assertEq(collateralToken.balanceOf(address(morpho)), 0);
     }
 }

--- a/test/unit/LendingAdapter/morpho/Borrow.t.sol
+++ b/test/unit/LendingAdapter/morpho/Borrow.t.sol
@@ -10,6 +10,8 @@ import {MorphoLendingAdapterBaseTest} from "./MorphoLendingAdapterBase.t.sol";
 
 contract MorphoLendingAdapterBorrowTest is MorphoLendingAdapterBaseTest {
     function testFuzz_borrow(uint256 amount) public {
+        vm.assume(amount > 0);
+
         // Deal Morpho the required debt token amount
         deal(address(debtToken), address(morpho), amount);
 
@@ -34,5 +36,12 @@ contract MorphoLendingAdapterBorrowTest is MorphoLendingAdapterBaseTest {
         vm.expectRevert(ILendingAdapter.Unauthorized.selector);
         vm.prank(caller);
         lendingAdapter.borrow(1);
+    }
+
+    function test_borrow_ZeroAmount() public {
+        // Nothing should happen
+        vm.prank(address(leverageManager));
+        lendingAdapter.borrow(0);
+        assertEq(debtToken.balanceOf(address(leverageManager)), 0);
     }
 }

--- a/test/unit/LendingAdapter/morpho/RemoveCollateral.t.sol
+++ b/test/unit/LendingAdapter/morpho/RemoveCollateral.t.sol
@@ -11,6 +11,8 @@ import {MorphoLendingAdapterBaseTest} from "./MorphoLendingAdapterBase.t.sol";
 
 contract MorphoLendingAdapterRemoveCollateralTest is MorphoLendingAdapterBaseTest {
     function testFuzz_removeCollateral(uint256 amount) public {
+        vm.assume(amount > 0);
+
         // Deal Morpho the required collateral token amount
         deal(address(collateralToken), address(morpho), amount);
 
@@ -26,6 +28,13 @@ contract MorphoLendingAdapterRemoveCollateralTest is MorphoLendingAdapterBaseTes
         lendingAdapter.removeCollateral(amount);
 
         assertEq(collateralToken.balanceOf(address(leverageManager)), amount);
+    }
+
+    function test_removeCollateral_ZeroAmount() public {
+        // Nothing should happen
+        vm.prank(address(leverageManager));
+        lendingAdapter.removeCollateral(0);
+        assertEq(collateralToken.balanceOf(address(morpho)), 0);
     }
 
     /// forge-config: default.fuzz.runs = 1

--- a/test/unit/LendingAdapter/morpho/Repay.t.sol
+++ b/test/unit/LendingAdapter/morpho/Repay.t.sol
@@ -12,6 +12,8 @@ contract MorphoLendingAdapterRepayTest is MorphoLendingAdapterBaseTest {
     address public alice = makeAddr("alice");
 
     function testFuzz_repay(uint256 amount) public {
+        vm.assume(amount > 0);
+
         // Deal alice the required debt
         deal(address(debtToken), alice, amount);
 
@@ -35,5 +37,11 @@ contract MorphoLendingAdapterRepayTest is MorphoLendingAdapterBaseTest {
         vm.stopPrank();
 
         assertEq(debtToken.balanceOf(address(morpho)), amount);
+    }
+
+    function test_repay_ZeroAmount() public {
+        // Nothing should happen
+        lendingAdapter.repay(0);
+        assertEq(debtToken.balanceOf(address(morpho)), 0);
     }
 }


### PR DESCRIPTION
Updated MorphoLendingAdapter to not make call to Morpho if action is going to be performed with zero amount because Morpho will make it revert