### PR TITLE
test: add more upgrade tests

### DIFF
--- a/test/unit/LeverageManager/AuthorizeUpgrade.t.sol
+++ b/test/unit/LeverageManager/AuthorizeUpgrade.t.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.26;
+
+// Dependency imports
+import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
+
+// Internal imports
+import {LeverageManagerBaseTest} from "./LeverageManagerBase.t.sol";
+
+contract AuthorizeUpgradeTest is LeverageManagerBaseTest {
+    function setUp() public override {
+        super.setUp();
+    }
+
+    /// forge-config: default.fuzz.runs = 1
+    function testFuzz_AuthorizeUpgrade(address caller, address newImplementation) public {
+        vm.startPrank(defaultAdmin);
+        leverageManager.grantRole(leverageManager.UPGRADER_ROLE(), caller);
+        vm.stopPrank();
+
+        // Expect not to revert
+        vm.prank(caller);
+        leverageManager.exposed_authorizeUpgrade(newImplementation);
+    }
+
+    /// forge-config: default.fuzz.runs = 1
+    function testFuzz_AuthorizeUpgrade_RevertIf_CallerIsNotUpgrader(address caller, address newImplementation) public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, caller, leverageManager.UPGRADER_ROLE()
+            )
+        );
+        vm.prank(caller);
+        leverageManager.exposed_authorizeUpgrade(newImplementation);
+    }
+}

--- a/test/unit/LeverageManager/harness/LeverageManagerHarness.t.sol
+++ b/test/unit/LeverageManager/harness/LeverageManagerHarness.t.sol
@@ -24,6 +24,10 @@ contract LeverageManagerHarness is LeverageManager, FeeManagerHarness {
         }
     }
 
+    function exposed_authorizeUpgrade(address newImplementation) external {
+        _authorizeUpgrade(newImplementation);
+    }
+
     function exposed_validateIsAuthorizedToRebalance(IStrategy strategy) external view {
         _validateIsAuthorizedToRebalance(strategy);
     }

--- a/test/unit/SwapAdapter/AuthorizeUpgrade.t.sol
+++ b/test/unit/SwapAdapter/AuthorizeUpgrade.t.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.26;
+
+// Dependency imports
+import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
+
+// Internal imports
+import {SwapAdapter} from "src/periphery/SwapAdapter.sol";
+import {SwapAdapterBaseTest} from "./SwapAdapterBase.t.sol";
+
+contract AuthorizeUpgradeTest is SwapAdapterBaseTest {
+    /// forge-config: default.fuzz.runs = 1
+    function testFuzz_AuthorizeUpgrade(address caller, address newImplementation) public {
+        vm.startPrank(defaultAdmin);
+        swapAdapter.grantRole(swapAdapter.UPGRADER_ROLE(), caller);
+        vm.stopPrank();
+
+        // Expect not to revert
+        vm.prank(caller);
+        swapAdapter.exposed_authorizeUpgrade(newImplementation);
+    }
+
+    /// forge-config: default.fuzz.runs = 1
+    function testFuzz_AuthorizeUpgrade_RevertIf_CallerIsNotUpgrader(address caller, address newImplementation) public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, caller, swapAdapter.UPGRADER_ROLE()
+            )
+        );
+        vm.prank(caller);
+        swapAdapter.exposed_authorizeUpgrade(newImplementation);
+    }
+}

--- a/test/unit/SwapAdapter/harness/SwapAdapterHarness.t.sol
+++ b/test/unit/SwapAdapter/harness/SwapAdapterHarness.t.sol
@@ -9,6 +9,10 @@ import {ISwapAdapter} from "src/interfaces/periphery/ISwapAdapter.sol";
 import {SwapAdapter} from "src/periphery/SwapAdapter.sol";
 
 contract SwapAdapterHarness is SwapAdapter {
+    function exposed_authorizeUpgrade(address newImplementation) external {
+        _authorizeUpgrade(newImplementation);
+    }
+
     function exposed_swapExactInputAerodrome(
         uint256 inputAmount,
         uint256 minOutputAmount,


### PR DESCRIPTION
- upgradeToAndCall tests for LeverageManager and SwapAdapter. Removed redundant AuthorizeUpgrade tests
- tests for upgrading BeaconProxyFactory's beacon implementation