### PR TITLE
feat: return early in _getAccruedManagementFee if duration since last…

### DIFF
--- a/src/FeeManager.sol
+++ b/src/FeeManager.sol
@@ -254,6 +254,7 @@ abstract contract FeeManager is IFeeManager, Initializable, AccessControlUpgrade
         uint120 lastManagementFeeAccrualTimestamp = getLastManagementFeeAccrualTimestamp(token);
         uint256 duration = block.timestamp - lastManagementFeeAccrualTimestamp;
 
+        // slither-disable-next-line timestamp,incorrect-equality
         if (duration == 0) {
             return 0;
         }


### PR DESCRIPTION
In deposit / mint and redeem / withdraw, we charge the management fee first, so we can save gas by returning early here when it's called by the preview funcs in those flows